### PR TITLE
Refine marking UX

### DIFF
--- a/lisp/Makefile
+++ b/lisp/Makefile
@@ -37,7 +37,7 @@ CASUAL_LIB_LISP_DIR=$(CASUAL_LIB_DIR)/lisp
 CASUAL_LIB_TEST_INCLUDES=$(CASUAL_LIB_DIR)/tests/casual-lib-test-utils.el
 EMACS_ELPA_DIR=$(HOME)/.config/emacs/elpa
 PACKAGE_PATHS=					\
--L $(EMACS_ELPA_DIR)/compat-29.1.4.5		\
+-L $(EMACS_ELPA_DIR)/compat-30.0.0.0		\
 -L $(EMACS_ELPA_DIR)/seq-2.24			\
 -L $(EMACS_ELPA_DIR)/transient-current		\
 -L $(CASUAL_LIB_LISP_DIR)

--- a/lisp/casual-ibuffer.el
+++ b/lisp/casual-ibuffer.el
@@ -54,7 +54,7 @@
 
    ["Mark"
     ("m" "Mark" ibuffer-mark-forward :transient t)
-    ("t" "Type›" casual-ibuffer-mark-tmenu)
+    ("t" "Type›" casual-ibuffer-mark-tmenu :transient t)
     ("r" "Regexp›" casual-ibuffer-mark-regexp-tmenu :transient t)
     ("u" "Unmark" ibuffer-unmark-forward :transient t)
     ("d" "For Deletion" ibuffer-mark-for-delete :transient t)
@@ -185,6 +185,7 @@
 
   [:class transient-row
           (casual-lib-quit-one)
+          ("U" "Unmark All" ibuffer-unmark-all-marks :transient t)
           (casual-lib-quit-all)])
 
 (transient-define-prefix casual-ibuffer-mark-regexp-tmenu ()
@@ -195,6 +196,7 @@
    ("c" "Content" ibuffer-mark-by-content-regexp)]
   [:class transient-row
           (casual-lib-quit-one)
+          ("U" "Unmark All" ibuffer-unmark-all-marks :transient t)
           (casual-lib-quit-all)])
 
 (provide 'casual-ibuffer)

--- a/tests/test-casual-ibuffer.el
+++ b/tests/test-casual-ibuffer.el
@@ -129,6 +129,7 @@
     (push (casualt-suffix-test-vector "D" #'ibuffer-mark-dissociated-buffers) test-vectors)
     (push (casualt-suffix-test-vector "s" #'ibuffer-mark-special-buffers) test-vectors)
     (push (casualt-suffix-test-vector "z" #'ibuffer-mark-compressed-file-buffers) test-vectors)
+    (push (casualt-suffix-test-vector "U" #'ibuffer-unmark-all-marks) test-vectors)
 
     (casualt-suffix-testbench-runner test-vectors
                                      #'casual-ibuffer-mark-tmenu
@@ -142,6 +143,7 @@
     (push (casualt-suffix-test-vector "n" #'ibuffer-mark-by-name-regexp) test-vectors)
     (push (casualt-suffix-test-vector "m" #'ibuffer-mark-by-mode-regexp) test-vectors)
     (push (casualt-suffix-test-vector "c" #'ibuffer-mark-by-content-regexp) test-vectors)
+    (push (casualt-suffix-test-vector "U" #'ibuffer-unmark-all-marks) test-vectors)
 
     (casualt-suffix-testbench-runner test-vectors
                                      #'casual-ibuffer-mark-regexp-tmenu


### PR DESCRIPTION
1. Menu is kept raised after calling a marking command.
   - This enables the user to immediately go into a operation on marked buffers.
2. Add "Unmark all" command to both marking menus.
